### PR TITLE
New test case for ServerRequest

### DIFF
--- a/std/http/_io_test.ts
+++ b/std/http/_io_test.ts
@@ -472,6 +472,12 @@ Deno.test("testReadRequestError", async function (): Promise<void> {
       assert(err instanceof (test.err as typeof Deno.errors.UnexpectedEof));
     } else {
       assert(req instanceof ServerRequest);
+      if (test.version) {
+        // return value order of parseHTTPVersion() function have to match with [req.protoMajor, req.protoMinor];
+        let version = parseHTTPVersion(test.in.split(" ", 3)[2]);
+        assertEquals(req.protoMajor, version[0]);
+        assertEquals(req.protoMinor, version[1]);
+      }
       assert(test.headers);
       assertEquals(err, undefined);
       assertNotEquals(req, null);


### PR DESCRIPTION
I created a new test case for checking protoMajor and protoMinor.
Needs to match with the assignation order [req.protoMajor, req.protoMinor] = parseHTTPVersion(...);